### PR TITLE
[Bugfix] 531511 - Downgrade FFMPEG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.79
+
+- [FFMPEG] Downgraded ffmpeg dependency version from 6.0.2 to 5.1.0
+
 ## 0.0.78
 
 - [DSSpinnerLoading] Set a default color

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blip_ds
 description: Blip Design System for Flutter.
-version: 0.0.78
+version: 0.0.79
 homepage: https://github.com/takenet/blip-ds-flutter#readme
 repository: https://github.com/takenet/blip-ds-flutter
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ffmpeg_kit_flutter_full_gpl: ^6.0.2
+  ffmpeg_kit_flutter_full_gpl: ^5.1.0
   just_audio: ^0.9.30
   rxdart: ^0.27.4
   flutter_spinkit: ^5.1.0

--- a/sample/pubspec.lock
+++ b/sample/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.77"
+    version: "0.0.79"
   boolean_selector:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: ffmpeg_kit_flutter_full_gpl
-      sha256: ab4c65439a1df22c944672c8bf249efb72b86a7feb4ab4c1fd252ca87adf6d8c
+      sha256: "523bd84eed67e157d8988889ceb21e7e3f58539af428bfe0b277a90c5793f61c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "5.1.0"
   ffmpeg_kit_flutter_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR aims to downgrade the FFMPEG dependency version from 6.0.2 to 5.1.0, which should improve stability and solve some issues related to the newest version.