### PR TITLE
[Bugfix] Get file extension from MIME Type with RegEx

### DIFF
--- a/lib/src/widgets/utils/ds_card.widget.dart
+++ b/lib/src/widgets/utils/ds_card.widget.dart
@@ -326,7 +326,7 @@ class DSCard extends StatelessWidget {
         replyContent: replyContent,
         size: size,
         filename: media.title ??
-            '${media.uri.hashCode}.${DSFileService.getFileExtensionFromMime(media.type)}',
+            '${media.uri.hashCode}.${DSFileService.getExtensionFromMimeType(media.type)}',
         borderRadius: borderRadius,
         style: style,
         shouldAuthenticate: shouldAuthenticate,


### PR DESCRIPTION
This PR aims to get file extension from mime type by using Regex. It solves an issue where some content-types has some extra parameters and not just the mime type itself.

Example: 

- [URL File](https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf)
- application/pdf; q=000.1