### PR TITLE
[Feature] #567769 - United File Message Bubble

### DIFF
--- a/lib/src/widgets/chat/ds_file_message_bubble.widget.dart
+++ b/lib/src/widgets/chat/ds_file_message_bubble.widget.dart
@@ -14,10 +14,12 @@ import '../texts/ds_body_text.widget.dart';
 import '../texts/ds_caption_small_text.widget.dart';
 import '../utils/ds_file_extension_icon.util.dart';
 import 'ds_message_bubble.widget.dart';
+import 'ds_show_more_text.widget.dart';
 
 class DSFileMessageBubble extends StatelessWidget {
   final DSAlign align;
   final String url;
+  final String? text;
   final int size;
   final String filename;
   final DSFileMessageBubbleController controller;
@@ -34,6 +36,7 @@ class DSFileMessageBubble extends StatelessWidget {
     required this.url,
     required this.size,
     required this.filename,
+    this.text,
     this.borderRadius = const [DSBorderRadius.all],
     this.shouldAuthenticate = false,
     DSMessageBubbleStyle? style,
@@ -60,14 +63,27 @@ class DSFileMessageBubble extends StatelessWidget {
           padding: EdgeInsets.zero,
           align: align,
           style: style,
-          child: SizedBox(
-            height: 80.0,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _buildIcon(),
-                _buildText(),
-              ],
+          child: Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: LayoutBuilder(
+              builder: (_, constraints) => Column(
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _buildIcon(),
+                      _buildTitle(),
+                    ],
+                  ),
+                  if (text?.isNotEmpty ?? false)
+                    DSShowMoreText(
+                      text: text!,
+                      maxWidth: constraints.maxWidth,
+                      align: align,
+                      style: style,
+                    )
+                ],
+              ),
             ),
           ),
         ),
@@ -101,7 +117,7 @@ class DSFileMessageBubble extends StatelessWidget {
     );
   }
 
-  Widget _buildText() {
+  Widget _buildTitle() {
     final color = style.isLightBubbleBackground(align)
         ? DSColors.neutralDarkCity
         : DSColors.neutralLightSnow;
@@ -131,7 +147,7 @@ class DSFileMessageBubble extends StatelessWidget {
                 controller.getFileSize(size),
                 color: color,
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/lib/src/widgets/utils/ds_card.widget.dart
+++ b/lib/src/widgets/utils/ds_card.widget.dart
@@ -323,6 +323,7 @@ class DSCard extends StatelessWidget {
       return DSFileMessageBubble(
         align: align,
         url: media.uri,
+        text: media.text,
         replyContent: replyContent,
         size: size,
         filename: media.title ??


### PR DESCRIPTION
This PR aims to make DSFileMessageBubble widget now render both text message (if there is one) and file to be shown in one united bubble instead of 2 separate messages.