### PR TITLE
[Feature] #565992 - DSCard now has key parameter in ds_group_card_widget

### DIFF
--- a/lib/src/widgets/utils/ds_group_card.widget.dart
+++ b/lib/src/widgets/utils/ds_group_card.widget.dart
@@ -251,6 +251,7 @@ class _DSGroupCardState extends State<DSGroupCard> {
               _getBorderRadius(length, msgCount, group['align']);
 
           final bubble = DSCard(
+            key: ValueKey<String>('${message.id}-${message.isUploading}'),
             type: message.type,
             content: message.content,
             align: message.align,


### PR DESCRIPTION
This PR aims to give a new parameter to ds_group_card_widget.dart in order to make media visibility on close ticket to work properly.