### PR TITLE
[Release] 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9
+
+- [DSEndCallsMessageBubble] Removed load recording state when session doesn't have available recording.
+  
 ## 0.1.8
 
 - Added translation to all hard coded texts.

--- a/lib/src/widgets/chat/calls/ds_end_calls_message_bubble.widget.dart
+++ b/lib/src/widgets/chat/calls/ds_end_calls_message_bubble.widget.dart
@@ -162,14 +162,13 @@ class _DSEndCallsMessageBubbleState extends State<DSEndCallsMessageBubble> {
               child: DSAnimatedSize(
                 child: FutureBuilder<String?>(
                   future: _session,
-                  builder: (_, snapshot) {
-                    return switch (snapshot.connectionState) {
-                      ConnectionState.done =>
-                        snapshot.hasError || (snapshot.data?.isEmpty ?? true)
-                            ? _buildError()
-                            : _buildAudioPlayer(snapshot.data!),
-                      _ => _buildLoading(),
-                    };
+                  builder: (_, snapshot) => switch (snapshot.connectionState) {
+                    ConnectionState.done => snapshot.hasError
+                        ? _buildError()
+                        : (snapshot.data?.isNotEmpty ?? false)
+                            ? _buildAudioPlayer(snapshot.data!)
+                            : const SizedBox.shrink(),
+                    _ => _buildLoading(),
                   },
                 ),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blip_ds
 description: Blip Design System for Flutter.
-version: 0.1.8
+version: 0.1.9
 homepage: https://github.com/takenet/blip-ds-flutter#readme
 repository: https://github.com/takenet/blip-ds-flutter
 


### PR DESCRIPTION
## 0.1.9

- [DSEndCallsMessageBubble] Removed load recording state when session doesn't have available recording.