### PR TITLE
Poc/code review

### DIFF
--- a/lib/src/services/ds_dialog.service.dart
+++ b/lib/src/services/ds_dialog.service.dart
@@ -53,6 +53,10 @@ class DSDialogService {
   }) {
     this.type = type;
 
+    for (var i = 0; i < 10; i++) {
+      print('hello ${i + 1}');
+    }
+
     _isDialogOpen = true;
 
     return showDialog<T>(

--- a/lib/src/widgets/buttons/ds_primary_button.widget.dart
+++ b/lib/src/widgets/buttons/ds_primary_button.widget.dart
@@ -23,7 +23,7 @@ class DSPrimaryButton extends DSButton {
     Color? foregroundColor,
   }) : super(
           backgroundColor: isEnabled
-              ? backgroundColor ?? DSColors.primaryNight
+              ? backgroundColor ?? DSColors.extendRedsLipstick
               : DSColors.disabledBg,
           foregroundColor: isEnabled
               ? foregroundColor ?? DSColors.neutralLightSnow

--- a/sample/pubspec.lock
+++ b/sample/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.5"
+    version: "0.3.7"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request includes a small but important change to the `DSPrimaryButton` class in the `lib/src/widgets/buttons/ds_primary_button.widget.dart` file. The change updates the default background color for enabled buttons.

* [`lib/src/widgets/buttons/ds_primary_button.widget.dart`](diffhunk://#diff-dc60ddce0c81d768128c8c1bfd156a0f7be9265fd639b986143aa4b4bb0426d2L26-R26): Changed the default background color for enabled buttons from `DSColors.primaryNight` to `DSColors.extendRedsLipstick`.